### PR TITLE
Fix loading stuck in user search

### DIFF
--- a/src/app/hooks/useUserSearch.ts
+++ b/src/app/hooks/useUserSearch.ts
@@ -54,6 +54,7 @@ export function useUserSearch(options: UseUserSearchOptions = {}): UseUserSearch
     // Clear results if query is empty
     if (!query || query.trim().length === 0) {
       clearResults();
+      setLoading(false);
       return;
     }
 
@@ -62,6 +63,7 @@ export function useUserSearch(options: UseUserSearchOptions = {}): UseUserSearch
       // Check minimum length
       if (query.trim().length < minSearchLength) {
         setError(`Search query must be at least ${minSearchLength} characters`);
+        setLoading(false);
         return;
       }
 


### PR DESCRIPTION
## Summary
- ensure loader resets when search query is empty or too short

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876751b65e08321a5d04d71fbb56c15