### PR TITLE
Add saving functionality for user settings

### DIFF
--- a/src/app/services/user-service.ts
+++ b/src/app/services/user-service.ts
@@ -312,6 +312,27 @@ export class UserService {
     }
   }
 
+  // Update user profile fields
+  static async updateUserProfile(userId: string, updates: Partial<UserProfile>): Promise<void> {
+    try {
+      const userRef = this.getUserProfileRef(userId);
+
+      const payload: Partial<UserProfile> = { ...updates };
+
+      if (updates.displayName) {
+        payload.displayNameLower = updates.displayName.toLowerCase();
+      }
+
+      await updateDoc(userRef, {
+        ...payload,
+        updatedAt: serverTimestamp() as Timestamp
+      });
+    } catch (error) {
+      console.error('Error updating user profile:', error);
+      throw new Error('Failed to update user profile');
+    }
+  }
+
   // FUTURE : Suggest users (autocomplete functionality)
   static async suggestUsers(prefix: string, limit: number = 5): Promise<string[]> {
     try {

--- a/src/app/ui/modals/user-settings.tsx
+++ b/src/app/ui/modals/user-settings.tsx
@@ -2,17 +2,24 @@
 
 import { X, Save } from 'lucide-react';
 import React, { useState, useEffect, useRef } from 'react';
+import { UserProfile } from '@/lib/definitions/user';
 
 interface UserSettingsModalProps {
-  onSave: () => void;
+  userProfile: UserProfile;
+  onSave: (updates: Partial<UserProfile>) => void;
   onClose: () => void;
 }
 
 export const UserSettingsModal = ({
+  userProfile,
   onSave,
   onClose,
 }: UserSettingsModalProps): React.ReactElement => {
   const [isAnimating, setIsAnimating] = useState(false);
+  const [displayName, setDisplayName] = useState(userProfile.displayName);
+  const [email, setEmail] = useState(userProfile.email || '');
+  const [bio, setBio] = useState(userProfile.bio);
+  const [favoriteGenres, setFavoriteGenres] = useState(userProfile.favoriteGenres.join(', '));
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -32,12 +39,21 @@ export const UserSettingsModal = ({
     setIsAnimating(true);
   }, []);
 
-  // TODO: Implement save functionality
   const handleSave = () => {
+    const updates: Partial<UserProfile> = {
+      displayName: displayName.trim(),
+      email: email.trim(),
+      bio: bio.trim(),
+      favoriteGenres: favoriteGenres
+        .split(',')
+        .map(g => g.trim())
+        .filter(g => g.length > 0)
+    };
+
     // Animate out before saving
     setIsAnimating(false);
     setTimeout(() => {
-      onSave();
+      onSave(updates);
     }, 200);
   };
 
@@ -78,8 +94,55 @@ export const UserSettingsModal = ({
 
         {/* Content */}
         <div className="p-6 space-y-6">
-          <div className="flex items-center gap-4">
-            {/* TODO: Add settings here */}
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Display Name
+              </label>
+              <input
+                type="text"
+                value={displayName}
+                onChange={e => setDisplayName(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Email
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Bio
+              </label>
+              <textarea
+                value={bio}
+                onChange={e => setBio(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                rows={3}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Favorite Genres
+              </label>
+              <input
+                type="text"
+                value={favoriteGenres}
+                onChange={e => setFavoriteGenres(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                placeholder="Comma separated"
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- implement updateUserProfile API in user service
- build UI fields for bio, display name, email and favorite genres in UserSettingsModal
- update UserMenu to use the new modal and persist settings to Firestore

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769330dd488321a2077cd235cd3a9b