### PR TITLE
Add shared form components

### DIFF
--- a/src/app/ui/components/button/index.tsx
+++ b/src/app/ui/components/button/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-type Variant = 'primary' | 'secondary' | 'danger'
+type Variant = 'primary' | 'secondary' | 'danger' | 'outline'
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: Variant
@@ -10,11 +10,13 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const baseClasses = {
   primary:
-    'px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors flex items-center gap-2',
+    'px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-md transition-colors flex items-center gap-2',
   secondary:
     'px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors',
   danger:
-    'px-4 py-2 text-white bg-red-600 hover:bg-red-700 transition-colors rounded-lg flex items-center gap-2',
+    'px-4 py-2 text-white bg-red-600 hover:bg-red-700 transition-colors rounded-md flex items-center gap-2',
+  outline:
+    'px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 flex items-center gap-2',
 }
 
 export default function Button({

--- a/src/app/ui/components/button/index.tsx
+++ b/src/app/ui/components/button/index.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import React from 'react'
+
+type Variant = 'primary' | 'secondary' | 'danger'
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant
+}
+
+const baseClasses = {
+  primary:
+    'px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors flex items-center gap-2',
+  secondary:
+    'px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors',
+  danger:
+    'px-4 py-2 text-white bg-red-600 hover:bg-red-700 transition-colors rounded-lg flex items-center gap-2',
+}
+
+export default function Button({
+  variant = 'primary',
+  className = '',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      className={`${baseClasses[variant]} ${className}`.trim()}
+    />
+  )
+}

--- a/src/app/ui/components/text-area/index.tsx
+++ b/src/app/ui/components/text-area/index.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import React from 'react'
+
+type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+
+const baseClass =
+  'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
+export default function TextArea({ className = '', ...props }: TextAreaProps) {
+  return <textarea {...props} className={`${baseClass} ${className}`.trim()} />
+}

--- a/src/app/ui/components/text-area/index.tsx
+++ b/src/app/ui/components/text-area/index.tsx
@@ -2,7 +2,9 @@
 
 import React from 'react'
 
-type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  ref?: React.RefObject<HTMLTextAreaElement | null>
+}
 
 const baseClass =
   'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500'

--- a/src/app/ui/components/text-input/index.tsx
+++ b/src/app/ui/components/text-input/index.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import React from 'react'
+
+type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const baseClass =
+  'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
+export default function TextInput({ className = '', ...props }: TextInputProps) {
+  return <input {...props} className={`${baseClass} ${className}`.trim()} />
+}

--- a/src/app/ui/components/text-input/index.tsx
+++ b/src/app/ui/components/text-input/index.tsx
@@ -2,11 +2,16 @@
 
 import React from 'react'
 
-type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>
+type TextInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  ref?: React.RefObject<HTMLInputElement | null>
+}
 
 const baseClass =
   'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500'
 
-export default function TextInput({ className = '', ...props }: TextInputProps) {
+export default function TextInput({
+  className = '',
+  ...props
+}: TextInputProps) {
   return <input {...props} className={`${baseClass} ${className}`.trim()} />
 }

--- a/src/app/ui/media-card.tsx
+++ b/src/app/ui/media-card.tsx
@@ -4,6 +4,7 @@ import { Media } from '@/lib/definitions/index'
 import { getMediaIcon } from '@/lib/utils'
 import Image from 'next/image'
 import UITooltip from '@/app/ui/components/tooltip'
+import Button from '@/app/ui/components/button'
 
 interface MediaCardProps {
   media: Media
@@ -50,10 +51,10 @@ export const MediaCard = ({
         <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2 mb-3">
           {media.overview}
         </p>
-        <button
+        <Button
           disabled={isRanked}
           onClick={() => onAddToRankings(media)}
-          className="w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded-md transition-colors flex items-center justify-center gap-2 disabled:bg-green-500 disabled:opacity-60"
+          className="w-full justify-center disabled:bg-green-500 disabled:opacity-60"
         >
           {!isRanked ? (
             <Plus className="w-4 h-4" />
@@ -61,7 +62,7 @@ export const MediaCard = ({
             <Check className="w-4 h-4" />
           )}
           {!isRanked ? 'Add to Rankings' : 'Added to Rankings'}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/app/ui/modals/add-family-member.tsx
+++ b/src/app/ui/modals/add-family-member.tsx
@@ -8,6 +8,7 @@ import { FamilyRole } from '@/lib/definitions/family'
 import { UserSearch } from '@/app/ui/user-search'
 import { UserProfile } from '@/lib/definitions/user'
 import Modal from '@/app/ui/components/modal'
+import Button from '../components/button'
 
 interface AddFamilyMemberModalProps {
   currentUserId: string
@@ -142,19 +143,18 @@ export const AddFamilyMemberModal: React.FC<AddFamilyMemberModalProps> = ({
 
           {/* Footer */}
           <div className="flex items-center justify-between gap-3 p-6 border-t border-gray-200 dark:border-gray-700">
-            <button
-              type="button"
+            <Button
+              variant="secondary"
               onClick={() => handleClose(close)}
-              className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
               disabled={loading}
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
               onClick={(e) => handleSubmit(e, close)}
               disabled={loading || !userId.trim()}
-              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors flex items-center gap-2"
+              className="flex items-center gap-2"
             >
               {loading ? (
                 <>
@@ -167,7 +167,7 @@ export const AddFamilyMemberModal: React.FC<AddFamilyMemberModalProps> = ({
                   Add Family Member
                 </>
               )}
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/src/app/ui/modals/family.tsx
+++ b/src/app/ui/modals/family.tsx
@@ -4,6 +4,9 @@ import React, { useState } from 'react'
 import { X, Users, Save, Loader2, Trash } from 'lucide-react'
 import { useFamilyStore } from '@/app/store/family-store'
 import Modal from '@/app/ui/components/modal'
+import TextInput from '@/app/ui/components/text-input'
+import TextArea from '@/app/ui/components/text-area'
+import Button from '@/app/ui/components/button'
 
 interface FamilyModalProps {
   currentUserId: string
@@ -124,13 +127,12 @@ export const FamilyModal: React.FC<FamilyModalProps> = ({
               >
                 Family Name *
               </label>
-              <input
+              <TextInput
                 id="family-name"
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Enter family name"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 required
               />
             </div>
@@ -142,13 +144,13 @@ export const FamilyModal: React.FC<FamilyModalProps> = ({
               >
                 Description (Optional)
               </label>
-              <textarea
+              <TextArea
                 id="family-description"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Tell us about your family..."
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+                className="resize-none"
               />
             </div>
 
@@ -170,30 +172,29 @@ export const FamilyModal: React.FC<FamilyModalProps> = ({
           {/* Footer */}
           <div className="flex items-center justify-between gap-3 p-6 border-t border-gray-200 dark:border-gray-700">
             {(isNewFamily || currentUserId !== currentFamily?.createdBy) && (
-              <button
+              <Button
                 type="button"
+                variant="secondary"
                 onClick={() => handleClose(close)}
-                className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
                 disabled={loading}
               >
                 Cancel
-              </button>
+              </Button>
             )}
             {!isNewFamily && currentUserId === currentFamily?.createdBy && (
-              <button
+              <Button
                 type="button"
+                variant="danger"
                 onClick={() => handleDelete(close)}
-                className="px-4 py-2 text-white bg-red-600 hover:bg-red-700 transition-colors rounded-lg flex items-center gap-2"
               >
                 <Trash className="w-4 h-4" />
                 Delete
-              </button>
+              </Button>
             )}
-            <button
+            <Button
               type="submit"
               onClick={(e) => handleSubmit(e, close)}
               disabled={loading || !name.trim()}
-              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors flex items-center gap-2"
             >
               {loading ? (
                 <>
@@ -206,7 +207,7 @@ export const FamilyModal: React.FC<FamilyModalProps> = ({
                   Save
                 </>
               )}
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/src/app/ui/modals/login.tsx
+++ b/src/app/ui/modals/login.tsx
@@ -106,7 +106,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
         <>
           <button
             onClick={close}
-            className="absolute top-2 right-2 p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            className="absolute top-2 right-2 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
             aria-label="Close modal"
           >
             <X className="w-5 h-5" />
@@ -328,11 +328,11 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
 
                   {/* Google Sign In */}
                   <div className="mt-6">
-                    <button
-                      type="button"
+                    <Button
+                      variant="outline"
                       onClick={() => handleGoogleSignIn(close)}
                       disabled={isSubmitting}
-                      className="w-full flex items-center justify-center gap-3 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-white dark:bg-gray-900 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full flex items-center justify-center gap-3 disabled:cursor-not-allowed"
                     >
                       <svg className="w-5 h-5" viewBox="0 0 24 24">
                         <path
@@ -353,7 +353,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                         />
                       </svg>
                       Sign in with Google
-                    </button>
+                    </Button>
                   </div>
                 </>
               )}

--- a/src/app/ui/modals/login.tsx
+++ b/src/app/ui/modals/login.tsx
@@ -11,6 +11,8 @@ import {
 } from 'firebase/auth'
 import { AlertCircle, Mail, User, Eye, EyeOff, Lock, X } from 'lucide-react'
 import Modal from '@/app/ui/components/modal'
+import TextInput from '@/app/ui/components/text-input'
+import Button from '@/app/ui/components/button'
 
 type AuthMode = 'login' | 'signup' | 'reset'
 
@@ -165,7 +167,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                         <User className="h-5 w-5 text-gray-400" />
                       </div>
-                      <input
+                      <TextInput
                         id="displayName"
                         name="displayName"
                         type="text"
@@ -173,7 +175,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                         required={mode === 'signup'}
                         value={displayName}
                         onChange={(e) => setDisplayName(e.target.value)}
-                        className="pl-10 w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        className="pl-10"
                         placeholder="John Doe"
                       />
                     </div>
@@ -192,7 +194,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                     <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                       <Mail className="h-5 w-5 text-gray-400" />
                     </div>
-                    <input
+                    <TextInput
                       id="email"
                       name="email"
                       type="email"
@@ -200,7 +202,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                       required
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
-                      className="pl-10 w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      className="pl-10"
                       placeholder="you@example.com"
                     />
                   </div>
@@ -219,7 +221,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                         <Lock className="h-5 w-5 text-gray-400" />
                       </div>
-                      <input
+                      <TextInput
                         id="password"
                         name="password"
                         type={showPassword ? 'text' : 'password'}
@@ -229,7 +231,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                         required
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
-                        className="pl-10 pr-10 w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        className="pl-10 pr-10"
                         placeholder={
                           mode === 'signup'
                             ? 'At least 6 characters'
@@ -264,7 +266,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                         <Lock className="h-5 w-5 text-gray-400" />
                       </div>
-                      <input
+                      <TextInput
                         id="confirmPassword"
                         name="confirmPassword"
                         type={showPassword ? 'text' : 'password'}
@@ -272,7 +274,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                         required
                         value={confirmPassword}
                         onChange={(e) => setConfirmPassword(e.target.value)}
-                        className="pl-10 w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        className="pl-10"
                         placeholder="Confirm your password"
                       />
                     </div>
@@ -293,10 +295,10 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                 )}
 
                 {/* Submit button */}
-                <button
+                <Button
                   type="submit"
                   disabled={isSubmitting}
-                  className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="w-full flex justify-center"
                 >
                   {isSubmitting
                     ? 'Please wait...'
@@ -305,7 +307,7 @@ export const LoginModal = ({ onClose }: LoginModalProps) => {
                       : mode === 'signup'
                         ? 'Create account'
                         : 'Send reset email'}
-                </button>
+                </Button>
               </form>
 
               {/* Divider */}

--- a/src/app/ui/modals/ranking.tsx
+++ b/src/app/ui/modals/ranking.tsx
@@ -4,6 +4,7 @@ import { Media, Ranking } from '@/lib/definitions/index'
 import { getMediaIcon } from '@/lib/utils'
 import Image from 'next/image'
 import Modal from '@/app/ui/components/modal'
+import TextArea from '@/app/ui/components/text-area'
 
 interface RankingModalProps {
   media?: Media
@@ -195,7 +196,7 @@ export const RankingModal = ({
                 ))}
               </div>
 
-              <textarea
+              <TextArea
                 ref={notesRef}
                 id="notes"
                 value={notes}

--- a/src/app/ui/modals/ranking.tsx
+++ b/src/app/ui/modals/ranking.tsx
@@ -3,6 +3,7 @@ import { X, Star, Calendar, Save } from 'lucide-react'
 import { Media, Ranking } from '@/lib/definitions/index'
 import { getMediaIcon } from '@/lib/utils'
 import Image from 'next/image'
+import Button from '@/app/ui/components/button'
 import Modal from '@/app/ui/components/modal'
 import TextArea from '@/app/ui/components/text-area'
 
@@ -227,19 +228,16 @@ export const RankingModal = ({
 
           {/* Footer */}
           <div className="flex-none p-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex justify-between gap-3">
-            <button
-              onClick={close}
-              className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
-            >
+            <Button variant="secondary" onClick={close}>
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={() => handleSave(close)}
-              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors font-medium flex items-center justify-center gap-2"
+              className="flex items-center justify-center gap-2"
             >
               <Save className="w-4 h-4" />
               {existingRanking ? 'Update' : 'Add'}
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/src/app/ui/modals/user-settings.tsx
+++ b/src/app/ui/modals/user-settings.tsx
@@ -4,6 +4,9 @@ import { X, Save } from 'lucide-react'
 import React, { useState } from 'react'
 import { UserProfile } from '@/lib/definitions/user'
 import Modal from '@/app/ui/components/modal'
+import TextInput from '@/app/ui/components/text-input'
+import TextArea from '@/app/ui/components/text-area'
+import Button from '@/app/ui/components/button'
 
 interface UserSettingsModalProps {
   userProfile: UserProfile
@@ -65,11 +68,10 @@ export const UserSettingsModal = ({
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Display Name
                 </label>
-                <input
+                <TextInput
                   type="text"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
 
@@ -77,11 +79,10 @@ export const UserSettingsModal = ({
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Email
                 </label>
-                <input
+                <TextInput
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
 
@@ -89,10 +90,9 @@ export const UserSettingsModal = ({
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Bio
                 </label>
-                <textarea
+                <TextArea
                   value={bio}
                   onChange={(e) => setBio(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   rows={3}
                 />
               </div>
@@ -101,11 +101,10 @@ export const UserSettingsModal = ({
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Favorite Genres
                 </label>
-                <input
+                <TextInput
                   type="text"
                   value={favoriteGenres}
                   onChange={(e) => setFavoriteGenres(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   placeholder="Comma separated"
                 />
               </div>
@@ -114,18 +113,12 @@ export const UserSettingsModal = ({
 
           {/* Footer */}
           <div className="p-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex justify-between gap-3">
-            <button
-              onClick={close}
-              className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
-            >
+            <Button variant="secondary" onClick={close}>
               Cancel
-            </button>
-            <button
-              onClick={() => handleSave(close)}
-              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg transition-colors font-medium flex items-center justify-center gap-2"
-            >
+            </Button>
+            <Button onClick={() => handleSave(close)} className="flex items-center justify-center gap-2">
               <Save className="w-4 h-4" /> Update
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/src/app/ui/modals/user-settings.tsx
+++ b/src/app/ui/modals/user-settings.tsx
@@ -65,10 +65,15 @@ export const UserSettingsModal = ({
           <div className="p-6 space-y-6">
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label
+                  htmlFor="settings-display-name"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
                   Display Name
                 </label>
                 <TextInput
+                  id="settings-display-name"
+                  name="displayName"
                   type="text"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
@@ -76,10 +81,15 @@ export const UserSettingsModal = ({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label
+                  htmlFor="settings-email"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
                   Email
                 </label>
                 <TextInput
+                  id="settings-email"
+                  name="email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -87,10 +97,15 @@ export const UserSettingsModal = ({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label
+                  htmlFor="settings-bio"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
                   Bio
                 </label>
                 <TextArea
+                  id="settings-bio"
+                  name="bio"
                   value={bio}
                   onChange={(e) => setBio(e.target.value)}
                   rows={3}
@@ -98,10 +113,15 @@ export const UserSettingsModal = ({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label
+                  htmlFor="settings-favorite-genres"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
                   Favorite Genres
                 </label>
                 <TextInput
+                  id="settings-favorite-genres"
+                  name="favoriteGenres"
                   type="text"
                   value={favoriteGenres}
                   onChange={(e) => setFavoriteGenres(e.target.value)}
@@ -116,7 +136,10 @@ export const UserSettingsModal = ({
             <Button variant="secondary" onClick={close}>
               Cancel
             </Button>
-            <Button onClick={() => handleSave(close)} className="flex items-center justify-center gap-2">
+            <Button
+              onClick={() => handleSave(close)}
+              className="flex items-center justify-center gap-2"
+            >
               <Save className="w-4 h-4" /> Update
             </Button>
           </div>

--- a/src/app/ui/user-menu.tsx
+++ b/src/app/ui/user-menu.tsx
@@ -9,6 +9,7 @@ import { UserProfile } from '@/lib/definitions/user'
 import { getInitials } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
+import Button from '@/app/ui/components/button'
 
 const LoginModal = dynamic(
   () => import('@/app/ui/modals/login').then((mod) => mod.LoginModal),
@@ -79,13 +80,10 @@ export function UserMenu() {
     return (
       <>
         <div className="relative" ref={menuRef}>
-          <button
-            onClick={handleLogin}
-            className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-          >
+          <Button onClick={handleLogin}>
             <User className="w-4 h-4" />
             Login
-          </button>
+          </Button>
         </div>
         {/* Login Modal (dynamic) */}
         {showLoginModal && (


### PR DESCRIPTION
## Summary
- create reusable `TextInput`, `TextArea` and `Button` components
- refactor `family`, `login` and `user-settings` modals to use the new components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687948a8b3f48321abcafb47a2561e4c